### PR TITLE
BUG FIX - game crash when building on the path

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,12 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.3.3
+Date: 2024-08-11
+  Changes:
+    - Fixed a crash that would occure when trying to build in the path.
+  Notes:
+    - Updated by cKrijgsman
+    - Original mod: https://mods.factorio.com/mod/towerdefense
+---------------------------------------------------------------------------------------------------
 Version: 0.3.2
 Date: 2022-03-13
   Changes:

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 0.3.3
 Date: 2024-08-11
   Changes:
     - Fixed a crash that would occure when trying to build in the path.
+    - Added the "fast-inserter" technology so that stack inserters can actualy be crafted.
   Notes:
     - Updated by cKrijgsman
     - Original mod: https://mods.factorio.com/mod/towerdefense

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "m-towerdefense",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "factorio_version": "1.1",
   "title": "Tower Defense",
   "author": "blueblue",

--- a/scenarios/towerdefense_basic/game_control.lua
+++ b/scenarios/towerdefense_basic/game_control.lua
@@ -912,7 +912,7 @@ Event.register(defines.events.on_pre_build, function(event)
     if not game_control or game_control.ended then return end
     if not game_control.lane_marker_surface then return end
     if game_control.lane_marker_surface.get_tile(event.position.x, event.position.y).name == "out-of-map" then
-        local success = player.clean_cursor()
+        local success = player.clear_cursor()
         if success then 
             player.print("Cannot build here.")
             player.play_sound{path="utility/cannot_build"}
@@ -923,7 +923,7 @@ Event.register(defines.events.on_pre_build, function(event)
             inventory.remove(stack)
             player.print("Cannot build here. As a penalty for trying we have removed " .. stack.count .. " " .. stack.name .. " from your inventory.")
             player.play_sound{path="utility/cannot_build"}            
-            player.clean_cursor()
+            player.clear_cursor()
         end
     end
 end)

--- a/scenarios/towerdefense_basic/game_control.lua
+++ b/scenarios/towerdefense_basic/game_control.lua
@@ -140,6 +140,7 @@ GameControl.game_constants = {
         "batteries",
         "laser",
         "battery",
+        "fast-inserter",
         "stack-inserter",
         "laser-turret",
         "modules",


### PR DESCRIPTION
in the `on_pre_build` event in `scenarios\towerdefense_basic\game_control.lua` updated the player API. `clean_cursor()` -> `clear_cursor()`